### PR TITLE
Add ability to see preview in full screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,45 @@
 			position: relative;
 		}
 
+		.fullscreen-toggle {
+			position: absolute;
+			top: 5px;
+			left: 5px;
+			z-index: 1000;
+			background: rgba(0, 0, 0, 0.2);
+			color: white;
+			border: none;
+			border-radius: 4px;
+			padding: 5px 8px;
+			cursor: pointer;
+			font-size: 16px;
+			transition: background-color 0.2s;
+		}
+
+		.fullscreen-toggle:hover {
+			background: rgba(0, 0, 0, 0.5);
+		}
+
+		.preview-pane.fullscreen {
+			position: fixed;
+			top: 0;
+			left: 0;
+			width: 100vw;
+			height: 100vh;
+			z-index: 9999;
+			background: white;
+		}
+
+		.preview-pane.fullscreen .fullscreen-toggle {
+			top: 20px;
+			left: 20px;
+		}
+
+		/* Hide editor when preview is fullscreen */
+		.editor-pane.hidden {
+			display: none;
+		}
+
 		#editor {
 			width: 100%;
 			height: 100%;
@@ -132,6 +171,7 @@
 	</div>
 	
 	<div class="preview-pane">
+		<button class="fullscreen-toggle" id="fullscreenToggle" title="Toggle fullscreen">⛶</button>
 		<iframe id="preview"></iframe>
 	</div>
 
@@ -140,6 +180,34 @@
 		let editorView;
 		const preview = document.getElementById('preview');
 		const storageKey = 'html-lab-content';
+		let isFullscreen = false;
+
+		// Fullscreen toggle functionality
+		function toggleFullscreen() {
+			const previewPane = document.querySelector('.preview-pane');
+			const editorPane = document.querySelector('.editor-pane');
+			const toggleButton = document.getElementById('fullscreenToggle');
+			
+			isFullscreen = !isFullscreen;
+			
+			if (isFullscreen) {
+				previewPane.classList.add('fullscreen');
+				editorPane.classList.add('hidden');
+				toggleButton.textContent = '⛶';
+				toggleButton.title = 'Exit fullscreen';
+			} else {
+				previewPane.classList.remove('fullscreen');
+				editorPane.classList.remove('hidden');
+				toggleButton.textContent = '⛶';
+				toggleButton.title = 'Toggle fullscreen';
+			}
+		}
+
+		// Add event listener for fullscreen toggle
+		document.addEventListener('DOMContentLoaded', function() {
+			const toggleButton = document.getElementById('fullscreenToggle');
+			toggleButton.addEventListener('click', toggleFullscreen);
+		});
 
 		function updatePreview() {
 			const code = editorView.state.doc.toString();

--- a/index.html
+++ b/index.html
@@ -182,7 +182,6 @@
 		const storageKey = 'html-lab-content';
 		let isFullscreen = false;
 
-		// Fullscreen toggle functionality
 		function toggleFullscreen() {
 			const previewPane = document.querySelector('.preview-pane');
 			const editorPane = document.querySelector('.editor-pane');
@@ -203,7 +202,6 @@
 			}
 		}
 
-		// Add event listener for fullscreen toggle
 		document.addEventListener('DOMContentLoaded', function() {
 			const toggleButton = document.getElementById('fullscreenToggle');
 			toggleButton.addEventListener('click', toggleFullscreen);


### PR DESCRIPTION
Small fullscreen icon is added to the top left of the preview panel. Clicking on it will full screen the preview. Clicking on it again will make it return to its original size.

<img width="1511" height="853" alt="Screenshot 2025-07-15 at 8 22 16 PM" src="https://github.com/user-attachments/assets/2d39251e-ad93-4ad0-802d-7649aec8d3fc" />
<img width="1512" height="856" alt="Screenshot 2025-07-15 at 8 22 33 PM" src="https://github.com/user-attachments/assets/0ffe6ba6-5894-4c13-9e71-ee54dbc775e2" />
